### PR TITLE
Switched to AsyncKeyedLock

### DIFF
--- a/SuperSafeBank.Persistence.Azure/SuperSafeBank.Persistence.Azure.csproj
+++ b/SuperSafeBank.Persistence.Azure/SuperSafeBank.Persistence.Azure.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR fixes 2 issues:

1) the semaphoreslim is waiting asynchronously but the cancellationToken is not being passed on, hence if the token is cancelled a thread would keep waiting.
2) there is a race condition. If thread A locks on 'ABC' and thread B tries to lock on 'ABC' it will need to wait for thread A to finish before it can go inside the lock. However when thread A finishes it removes 'ABC' from the dictionary while thread B is still processing for that key. That means that a thread C could come along and starts processing 'ABC' concurrently with thread B.

This code will also reduce memory allocations through pooling.